### PR TITLE
add whitelist for ReStock

### DIFF
--- a/GameData/MandatoryRCSPartPack/MandatoryRCSPartPack.restockwhitelist
+++ b/GameData/MandatoryRCSPartPack/MandatoryRCSPartPack.restockwhitelist
@@ -1,0 +1,1 @@
+Squad/Parts/Utility/linearRCS/rcs.dds


### PR DESCRIPTION
If not, the RCS parts got no textures when ReStock is also installed.
(RCS_RV105Variants)