### PR TITLE
Allow CKAN installation on newer KSPs

### DIFF
--- a/GameData/MandatoryRCSPartPack/MandatoryRCSPartPack.version
+++ b/GameData/MandatoryRCSPartPack/MandatoryRCSPartPack.version
@@ -30,7 +30,7 @@
   "KSP_VERSION_MAX":
   {
       "MAJOR": 1,
-      "MINOR": 7,
-      "PATCH": 9
+      "MINOR": 12,
+      "PATCH": 99
   }
 }


### PR DESCRIPTION
It's a part pack, it's safe. And I've been using it on 1.10 for months with no problem.